### PR TITLE
feat: add product section navigation link to header

### DIFF
--- a/app/components/layout/Navigation.tsx
+++ b/app/components/layout/Navigation.tsx
@@ -9,6 +9,7 @@ const Navigation = () => {
   const [activeSection, setActiveSection] = useState<string>('');
 
   const navItems = [
+    { label: 'プロダクト', href: '#project' },
     { label: 'Profile', href: '#profile' },
     { label: 'Skill', href: '#skill' },
     { label: 'Position', href: '#position' },
@@ -70,6 +71,8 @@ const Navigation = () => {
                     ? 'text-[#4A6670] dark:text-white font-medium'
                     : 'text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white'
                   }`}
+                  aria-label={`${item.label}セクションへ移動`}
+                  role="link"
                 >
                   {item.label}
                 </Link>


### PR DESCRIPTION
## Summary
- Add "プロダクト" navigation link in header's leftmost position
- Implements smooth scrolling to project section on click
- Includes accessibility features and responsive design

## Test plan
- [ ] Verify link appears in header's left area
- [ ] Test smooth scrolling to project section
- [ ] Confirm hover effects work properly
- [ ] Test mobile responsiveness
- [ ] Verify keyboard navigation works
- [ ] Test screen reader compatibility

Fixes #8

🤖 Generated with [Claude Code](https://claude.ai/code)