### PR TITLE
フッターの日付自動更新機能を実装

### DIFF
--- a/app/components/layout/Footer.tsx
+++ b/app/components/layout/Footer.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+export default function Footer() {
+  const [currentDate, setCurrentDate] = useState<string>('');
+
+  useEffect(() => {
+    // 現在の日付を取得し、YYYY-MM-DD形式でフォーマット
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, '0');
+    const day = String(now.getDate()).padStart(2, '0');
+    const formattedDate = `${year}-${month}-${day}`;
+    
+    setCurrentDate(formattedDate);
+  }, []);
+
+  return (
+    <footer className="py-6 bg-white dark:bg-gray-900 border-t border-gray-100 dark:border-gray-800 animate-fade-in-delay-400">
+      <div className="max-w-4xl mx-auto px-4 text-center">
+        <p className="text-sm text-gray-500 dark:text-gray-400 font-montserrat">
+          Designed & Built by{' '}
+          <span className="text-[#4A6670] dark:text-gray-300">yokomachi</span>
+          <span className="mx-2">•</span>
+          Last updated: {currentDate}
+        </p>
+      </div>
+    </footer>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import PositionSection from './components/layout/PositionSection';
 import CertificationSection from './components/layout/CertificationSection';
 import ProjectSection from './components/layout/ProjectSection';
 import LinkSection from './components/layout/LinkSection';
+import Footer from './components/layout/Footer';
 
 export default function Home() {
   return (
@@ -36,16 +37,7 @@ export default function Home() {
       </main>
 
       {/* Footer */}
-      <footer className="py-6 bg-white dark:bg-gray-900 border-t border-gray-100 dark:border-gray-800 animate-fade-in-delay-400">
-        <div className="max-w-4xl mx-auto px-4 text-center">
-          <p className="text-sm text-gray-500 dark:text-gray-400 font-montserrat">
-            Designed & Built by{' '}
-            <span className="text-[#4A6670] dark:text-gray-300">yokomachi</span>
-            <span className="mx-2">•</span>
-            Last updated: January 2025
-          </p>
-        </div>
-      </footer>
+      <Footer />
     </div>
   );
 }


### PR DESCRIPTION
フッターの日付を現在日に自動更新する機能を実装しました。

## 変更点
- 新しいFooterコンポーネントを作成し、useEffectで現在日付を動的に取得
- YYYY-MM-DD形式での日付フォーマットを実装
- ページロード時の自動実行を確認
- ハードコーディングされた日付をReactコンポーネントに置き換え

Fixes #12

Generated with [Claude Code](https://claude.ai/code)