### PR TITLE
feat: ヘッダー中央に今日の運勢表示機能を追加

### DIFF
--- a/app/components/layout/Navigation.tsx
+++ b/app/components/layout/Navigation.tsx
@@ -58,34 +58,48 @@ const Navigation = () => {
   return (
     <nav className="fixed top-0 left-0 right-0 bg-white/70 dark:bg-gray-900/70 backdrop-blur-sm z-50">
       <div className="max-w-7xl mx-auto px-4">
-        <div className="flex justify-between items-center">
-          <ul className="flex space-x-6 py-4">
-            {navItems.map((item) => (
-              <li key={item.href}>
-                <Link
-                  href={item.href}
-                  onClick={(e) => handleScroll(e, item.href)}
-                  className={`text-sm transition-colors ${
-                    activeSection === item.href.replace('#', '')
-                    ? 'text-[#4A6670] dark:text-white font-medium'
-                    : 'text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white'
-                  }`}
-                >
-                  {item.label}
-                </Link>
-              </li>
-            ))}
-          </ul>
-          <div className="flex items-center gap-2">
-            <Link
-              href="https://github.com/n-yokomachi/portfolio"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors text-gray-600 dark:text-gray-300 hover:text-[#4A6670] dark:hover:text-white"
-            >
-              <GithubIcon className="w-5 h-5" />
-            </Link>
-            <ThemeToggle />
+        <div className="flex items-center py-4">
+          {/* Left: Navigation Items */}
+          <div className="flex-1">
+            <ul className="flex space-x-2 md:space-x-6">
+              {navItems.map((item) => (
+                <li key={item.href}>
+                  <Link
+                    href={item.href}
+                    onClick={(e) => handleScroll(e, item.href)}
+                    className={`text-xs md:text-sm transition-colors ${
+                      activeSection === item.href.replace('#', '')
+                      ? 'text-[#4A6670] dark:text-white font-medium'
+                      : 'text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white'
+                    }`}
+                  >
+                    {item.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+          
+          {/* Center: Today's Fortune */}
+          <div className="flex-1 text-center hidden sm:block">
+            <span className="text-xs md:text-sm font-medium text-[#4A6670] dark:text-white">
+              今日の運勢: 大吉
+            </span>
+          </div>
+          
+          {/* Right: GitHub Link and Theme Toggle */}
+          <div className="flex-1 flex justify-end">
+            <div className="flex items-center gap-1 md:gap-2">
+              <Link
+                href="https://github.com/n-yokomachi/portfolio"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="p-1.5 md:p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors text-gray-600 dark:text-gray-300 hover:text-[#4A6670] dark:hover:text-white"
+              >
+                <GithubIcon className="w-4 h-4 md:w-5 md:h-5" />
+              </Link>
+              <ThemeToggle />
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 概要
ヘッダー中央に今日の運勢を表示する機能を実装しました。

## 変更内容
- Navigationコンポーネントを3分割レイアウトに変更
- 中央に「今日の運勢: 大吉」を表示
- flexboxを使用した中央揃えのレスポンシブデザイン
- 小画面では運勢表示を非表示にして最適化

Closes #18

----

Generated with [Claude Code](https://claude.ai/code)